### PR TITLE
Add CSS scoping rule to documentation and update next-env.d.ts

### DIFF
--- a/.claude/skills/html-to-nextjs-migration/SKILL.md
+++ b/.claude/skills/html-to-nextjs-migration/SKILL.md
@@ -245,3 +245,4 @@ Do NOT redefine these in page-specific CSS. Use them directly in TSX:
 - **Never use `{"\n"}` for line breaks inside `.code-block`** — `.code-block` の `white-space` はデフォルト `normal` のため `{"\n"}` はスペースに正規化される。各行を `<div className="code-line">...</div>` でラップすること（`.code-line` には `white-space: pre` が定義済み）
 - **Never align tabular data with spaces in `.code-block`** — デシジョンテーブルや行列データはフォント変更で列ズレが起きるため `<table>` 要素を使うこと
 - **Never remove page-specific anchor nav bars** — ページ固有のスティッキーナビ（`IntersectionObserver` 付き）はグローバル Header と別物。`'use client'` コンポーネントとして移行し `top: 60px` を設定すること
+- **Never duplicate page scope classes in CSS selectors** — `.page-class .alert.page-class .green` ではなく、`.page-class .alert.green` のようにページクラスは最上位の1回のみ使用すること

--- a/.gemini/skills/html-to-nextjs-migration/SKILL.md
+++ b/.gemini/skills/html-to-nextjs-migration/SKILL.md
@@ -243,3 +243,4 @@ Do NOT redefine these in page-specific CSS. Use them directly in TSX:
 - **Never use `{"\n"}` for line breaks inside `.code-block`** — `.code-block` の `white-space` はデフォルト `normal` のため `{"\n"}` はスペースに正規化される。各行を `<div className="code-line">...</div>` でラップすること（`.code-line` には `white-space: pre` が定義済み）
 - **Never align tabular data with spaces in `.code-block`** — デシジョンテーブルや行列データはフォント変更で列ズレが起きるため `<table>` 要素を使うこと
 - **Never remove page-specific anchor nav bars** — ページ固有のスティッキーナビ（`IntersectionObserver` 付き）はグローバル Header と別物。`'use client'` コンポーネントとして移行し `top: 60px` を設定すること
+- **Never duplicate page scope classes in CSS selectors** — `.page-class .alert.page-class .green` ではなく、`.page-class .alert.green` のようにページクラスは最上位の1回のみ使用すること

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -96,3 +96,9 @@ This project is a Next.js (App Router) web application designed as a comprehensi
 - HTML の `<nav>`（ページ内アンカー付き）はグローバル Header とは別物。削除せず `'use client'` コンポーネントとして移行する
 - CSS: `position: sticky; top: 60px; z-index: 40`（Header は `fixed` / 高さ 60px / `z-50`）
 - `IntersectionObserver` は `useEffect` で設定し、クリーンアップで `obs.disconnect()` を呼ぶ
+
+### CSSセレクタのスコープ（クラス重複）
+
+- ページ固有のCSSを作成する際、`.istqb-ctal-tm-page` のようなページ固有クラスを親に指定しますが、子要素のモディファイアなどで再度同じクラスを重複させないように注意してください。
+- ❌ NG: `.page-class .alert.page-class .green`
+- ✅ OK: `.page-class .alert.green`

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
  具体的な更新内容

  1. SKILL.md へのピットフォール（注意点）追加
  移行時の「CSS Pitfalls Checklist（よくある失敗チェックリスト）」の表に、ページクラスの重複に関する行を追加しました。
   * 追加項目: Page class duplication | ❌ .page-class .component.page-class .modifier | ✅ .page-class .component.modifier

  2. SKILL.md の制約（Constraints）へのルール追加
  ファイル末尾の Constraints セクションに、CSSセレクタ設計に関する厳格なルールを追加しました。
   * 追加項目: - **Never duplicate page scope classes in CSS selectors** — \.page-class .alert.page-class .green\ ではなく、\.page-class .alert.green\
     のようにページクラスは最上位の1回のみ使用すること

  3. GEMINI.md の移行ガイドライン追記
  GEMINI.md の「HTML → Next.js 移行
  注意事項」セクションに、CSSスコープに関する新たな小項目を追加し、LLMエージェントがコードを生成する際にクラスを重複させないように明記しました。
   * 追加項目: ### CSSセレクタのスコープ（クラス重複） として、ページ固有クラスを指定する際の子要素での重複回避についての具体例（NG例/OK例）を記載。